### PR TITLE
[Bugfix][Model] Fix DeepSeek-OCR-2 chat template to include BOS token

### DIFF
--- a/vllm/transformers_utils/configs/deepseek_vl2.py
+++ b/vllm/transformers_utils/configs/deepseek_vl2.py
@@ -119,8 +119,9 @@ class DeepseekVLV2Config(PretrainedConfig):
         self.candidate_resolutions = candidate_resolutions
         self.vocab_size = self.text_config.vocab_size
 
-        # update model_type for OCR model
-        if "DeepseekOCRForCausalLM" in (
-            self.architectures or kwargs.get("architectures", [])
-        ):
+        # update model_type for OCR models
+        architectures = self.architectures or kwargs.get("architectures", [])
+        if "DeepseekOCRForCausalLM" in architectures:
             self.model_type = "deepseek_ocr"
+        elif "DeepseekOCR2ForCausalLM" in architectures:
+            self.model_type = "deepseek_ocr2"


### PR DESCRIPTION
## Summary
This PR fixes an issue where DeepSeek-OCR-2 models return empty responses when using the `/v1/chat/completions` endpoint.

## Root Cause
DeepSeek-OCR-2 models have `model_type='deepseek_vl_v2'` but require a BOS (beginning-of-sentence) token for proper inference. The existing code path used `template_deepseek_vl2.jinja` which doesn't include BOS.

## Fix
Added `_get_deepseek_vl_v2_chat_template_fallback()` function that:
- Returns `template_deepseek_ocr.jinja` for OCR models (contains `{{ bos_token }}`)
- Returns `template_deepseek_vl2.jinja` for standard VL2 models

## Testing
Tested with `unsloth/DeepSeek-OCR-2` and `deepseek-ai/DeepSeek-OCR-2`:
- `/v1/chat/completions` with image: Returns correct OCR text ✅
- `/v1/completions` with text: Returns correct completions ✅
- Python `generate()` API: Works as expected ✅

## Checklist
- [x] Pre-commit checks pass
- [x] Signed-off-by included
- [x] PR title follows convention
